### PR TITLE
Request for pulling PIN entering functionality to Rilmodem

### DIFF
--- a/ofono/drivers/rilmodem/rilutil.c
+++ b/ofono/drivers/rilmodem/rilutil.c
@@ -451,7 +451,7 @@ gboolean ril_util_parse_sim_status(struct ril_msg *message,
 	ims_index = parcel_r_int32(&rilp);
 	num_apps = parcel_r_int32(&rilp);
 
-        ril_start_response;
+	ril_start_response;
 
 	/* TODO:
 	 * How do we handle long (>80 chars) ril_append_print_buf strings?
@@ -487,7 +487,6 @@ gboolean ril_util_parse_sim_status(struct ril_msg *message,
 		* according to traces seems to not zero if app is active.
 		*/
 		if (app_type != 0) {
-			DBG("PASSWORD REQUIRED");
 			switch (app_state) {
 			case APPSTATE_PIN:
 				sd->passwd_state = OFONO_SIM_PASSWORD_SIM_PIN;

--- a/ofono/plugins/ril.c
+++ b/ofono/plugins/ril.c
@@ -129,7 +129,7 @@ static void sim_status_cb(struct ril_msg *message, gpointer user_data)
 	DBG("");
 
 	/* Returns TRUE if cardstate == PRESENT */
-	if (ril_util_parse_sim_status(message, NULL)) {
+	if (ril_util_parse_sim_status(message, NULL, ril)) {
 		DBG("have_sim = TRUE; powering on modem.");
 
 		/* TODO: check PinState=DISABLED, for now just


### PR DESCRIPTION
Enables basic functionality for PIN entering in Rilmodem.
Enables implementing the PIN locking and unlocking.

Signed-off-by: jussi.kangas@tieto.com
