### PR TITLE
Enabled conference calls, and hold/resume

### DIFF
--- a/ofono/drivers/rilmodem/voicecall.c
+++ b/ofono/drivers/rilmodem/voicecall.c
@@ -455,6 +455,13 @@ static void ril_private_chat(struct ofono_voicecall *vc, int id,
 	if (cb) cb(&error, data);
 }
 
+static void ril_swap_without_accept(struct ofono_voicecall *vc,
+			ofono_voicecall_cb_t cb, void *data)
+{
+	ril_template(RIL_REQUEST_SWITCH_HOLDING_AND_ACTIVE, vc, generic_cb, 0,
+				NULL, 0, cb, data);
+}
+
 static gboolean ril_delayed_register(gpointer user_data)
 {
 	struct ofono_voicecall *vc = user_data;
@@ -531,7 +538,8 @@ static struct ofono_voicecall_driver driver = {
 	.hangup_all		= ril_hangup_all,
 	.send_tones		= ril_send_dtmf,
 	.create_multiparty	= ril_create_multiparty,
-	.private_chat		= ril_private_chat
+	.private_chat		= ril_private_chat,
+	.swap_without_accept	= ril_swap_without_accept
 };
 
 void ril_voicecall_init(void)


### PR DESCRIPTION
Added rilmodem driver implementation for creating conference calls (up to 5 calls in one conference), and splitting a call out of a conference. Also, implemented holding/resuming/swapping voice calls.
