### PR TITLE
Request for pulling compilation warning fix in to main branch

### DIFF
--- a/ofono/drivers/rilmodem/rilmodem.h
+++ b/ofono/drivers/rilmodem/rilmodem.h
@@ -62,3 +62,6 @@ extern void ril_call_settings_exit(void);
 extern void ril_call_forwarding_init(void);
 extern void ril_call_forwarding_exit(void);
 
+extern void ril_phonebook_init(void);
+extern void ril_phonebook_exit(void);
+


### PR DESCRIPTION
Bugfix for removing compilation warning about not declaring
phonebook initialisation properly

Signed-off-by: Jussi Kangas jussi.kangas@oss.tieto.com
