### PR TITLE
Request for pulling basic SMS cell broadcast implementation to main branch

### DIFF
--- a/ofono/Makefile.am
+++ b/ofono/Makefile.am
@@ -130,7 +130,8 @@ builtin_sources += drivers/rilmodem/rilmodem.h \
 			drivers/rilmodem/phonebook.c \
 			drivers/rilmodem/ussd.c \
 			drivers/rilmodem/call-settings.c \
-			drivers/rilmodem/call-forwarding.c
+			drivers/rilmodem/call-forwarding.c \
+			drivers/rilmodem/cbs.c
 
 endif
 

--- a/ofono/drivers/rilmodem/cbs.c
+++ b/ofono/drivers/rilmodem/cbs.c
@@ -1,0 +1,152 @@
+/*
+ *
+ *  oFono - Open Source Telephony
+ *
+ *  Copyright (C) 2008-2011  Intel Corporation. All rights reserved.
+ *  Copyright (C) 2013 Jolla Ltd
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2 as
+ *  published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#define _GNU_SOURCE
+#include <string.h>
+#include <stdio.h>
+
+#include <glib.h>
+
+#include <ofono/log.h>
+#include <ofono/modem.h>
+#include <ofono/cbs.h>
+
+#include "gril.h"
+#include "grilutil.h"
+
+#include "rilmodem.h"
+#include "ril_constants.h"
+
+struct cbs_data {
+	GRil *ril;
+};
+
+static void ril_set_topics(struct ofono_cbs *cbs, const char *topics,
+				ofono_cbs_set_cb_t cb, void *user_data)
+{
+	/*
+	 * Although this does not do anything real
+	 * towards network or modem, it is needed
+	 * because without it ofono core does not
+	 * change powered flag and it would reject
+	 * incoming cb messages.
+	 */
+	CALLBACK_WITH_SUCCESS(cb, user_data);
+}
+
+static void ril_clear_topics(struct ofono_cbs *cbs,
+				ofono_cbs_set_cb_t cb, void *user_data)
+{
+	/*
+	 * Although this does not do anything real
+	 * towards network or modem, it is needed
+	 * because without it ofono core does not
+	 * change powered flag and it would allow
+	 * incoming cb messages.
+	 */
+	CALLBACK_WITH_SUCCESS(cb, user_data);
+}
+
+static void ril_cbs_notify(struct ril_msg *message, gpointer user_data)
+{
+	struct ofono_cbs *cbs = user_data;
+
+	/*
+	 * Ofono does not support UMTS CB - see
+	 * src/smsutil.c method cbs_decode.
+	 * But let's let the core to make
+	 * the rejection reserve memory here
+	 * for maximum UMTS CB length
+	 */
+
+	unsigned char pdu[1252];
+	char *resp;
+	struct parcel rilp;
+
+	ril_util_init_parcel(message, &rilp);
+
+	resp = parcel_r_string(&rilp);
+
+	memcpy(resp, pdu, strlen((char *)resp));
+
+	ofono_cbs_notify(cbs, pdu, strlen((char *)resp));
+}
+
+static gboolean ril_delayed_register(gpointer user_data)
+{
+	struct ofono_cbs *cbs = user_data;
+	struct cbs_data *cd = ofono_cbs_get_data(cbs);
+
+	ofono_cbs_register(cbs);
+
+	g_ril_register(cd->ril, RIL_UNSOL_RESPONSE_NEW_BROADCAST_SMS,
+			ril_cbs_notify,	cbs);
+
+	return FALSE;
+}
+
+static int ril_cbs_probe(struct ofono_cbs *cbs, unsigned int vendor,
+				void *user)
+{
+	GRil *ril = user;
+
+	struct cbs_data *cd = g_try_new0(struct cbs_data, 1);
+
+	cd->ril = g_ril_clone(ril);
+
+	ofono_cbs_set_data(cbs, cd);
+
+	g_timeout_add_seconds(2, ril_delayed_register, cbs);
+
+	return 0;
+}
+
+static void ril_cbs_remove(struct ofono_cbs *cbs)
+{
+	struct cbs_data *cd = ofono_cbs_get_data(cbs);
+	ofono_cbs_set_data(cbs, NULL);
+	g_ril_unref(cd->ril);
+	g_free(cd);
+}
+
+static struct ofono_cbs_driver driver = {
+	.name			= "rilmodem",
+	.probe			= ril_cbs_probe,
+	.remove			= ril_cbs_remove,
+	.set_topics		= ril_set_topics,
+	.clear_topics	= ril_clear_topics
+};
+
+void ril_cbs_init(void)
+{
+	ofono_cbs_driver_register(&driver);
+}
+
+void ril_cbs_exit(void)
+{
+	ofono_cbs_driver_unregister(&driver);
+}
+

--- a/ofono/drivers/rilmodem/rilmodem.c
+++ b/ofono/drivers/rilmodem/rilmodem.c
@@ -52,6 +52,7 @@ static int rilmodem_init(void)
 	ril_ussd_init();
 	ril_call_settings_init();
 	ril_call_forwarding_init();
+	ril_cbs_init();
 
 	return 0;
 }
@@ -73,6 +74,7 @@ static void rilmodem_exit(void)
 	ril_ussd_exit();
 	ril_call_settings_exit();
 	ril_call_forwarding_exit();
+	ril_cbs_exit();
 }
 
 OFONO_PLUGIN_DEFINE(rilmodem, "RIL modem driver", VERSION,

--- a/ofono/drivers/rilmodem/rilmodem.h
+++ b/ofono/drivers/rilmodem/rilmodem.h
@@ -62,6 +62,9 @@ extern void ril_call_settings_exit(void);
 extern void ril_call_forwarding_init(void);
 extern void ril_call_forwarding_exit(void);
 
+extern void ril_cbs_init(void);
+extern void ril_cbs_exit(void);
+
 extern void ril_phonebook_init(void);
 extern void ril_phonebook_exit(void);
 

--- a/ofono/plugins/ril.c
+++ b/ofono/plugins/ril.c
@@ -265,6 +265,7 @@ static void ril_post_online(struct ofono_modem *modem)
 	ofono_netreg_create(modem, 0, "rilmodem", ril->modem);
 	ofono_ussd_create(modem, 0, "rilmodem", ril->modem);
 	ofono_call_settings_create(modem, 0, "rilmodem", ril->modem);
+	ofono_cbs_create(modem, 0, "rilmodem", ril->modem);
 }
 
 static int ril_enable(struct ofono_modem *modem)


### PR DESCRIPTION
Added handling of incoming SMS broadcast messages. Implementation
should enable device to receive emergency cell broadcast messages
but it needs more testing. Currently it has been tested only against
stub.

Signed-off-by: Jussi Kangas jussi.kangas@oss.tieto.com
