### PR TITLE
Add /var/lib/ofono directory with correct permissions to rpm.

### DIFF
--- a/rpm/ofono.spec
+++ b/rpm/ofono.spec
@@ -111,6 +111,7 @@ systemctl daemon-reload
 # This file is part of phonesim and not needed with ofono.
 %exclude %{_sysconfdir}/ofono/phonesim.conf
 %doc /usr/share/man/man8/ofonod.8.gz
+%dir %attr(775,radio,radio) /var/lib/ofono
 # << files
 
 %files devel


### PR DESCRIPTION
Settings were not being saved as ofono was failing to create /var/lib/ofono because it is no longer run as root. Added /var/lib/ofono to rpm owned by radio.radio.
