### PR TITLE
Request for pulling the application type checking fix for phonebook to main branch

### DIFF
--- a/ofono/drivers/rilmodem/rilutil.c
+++ b/ofono/drivers/rilmodem/rilutil.c
@@ -52,8 +52,6 @@ struct ril_util_sim_state_query {
 
 static gboolean cpin_check(gpointer userdata);
 
-int current_active_app = RIL_APPTYPE_UNKNOWN;
-
 void decode_ril_error(struct ofono_error *error, const char *final)
 {
 	if (!strcmp(final, "OK")) {
@@ -660,9 +658,3 @@ void ril_util_free_sim_apps(struct sim_app **apps, guint num_apps) {
 		g_free(apps[i]);
 	}
 }
-
-gint ril_get_app_type()
-{
-	return current_active_app;
-}
-

--- a/ofono/drivers/rilmodem/sim.c
+++ b/ofono/drivers/rilmodem/sim.c
@@ -80,6 +80,8 @@
 
 /* Current SIM */
 static struct ofono_sim *current_sim;
+/* Current active app */
+int current_active_app = RIL_APPTYPE_UNKNOWN;
 
 /*
  * TODO: CDMA/IMS
@@ -591,6 +593,7 @@ static void sim_status_cb(struct ril_msg *message, gpointer user_data)
 		for (i = 0; i < status.num_apps; i++) {
 			if (i == search_index &&
 				apps[i]->app_type != RIL_APPTYPE_UNKNOWN) {
+				current_active_app = apps[i]->app_type;
 				configure_active_app(sd, apps[i], i);
 				break;
 			}
@@ -907,6 +910,8 @@ static int ril_sim_probe(struct ofono_sim *sim, unsigned int vendor,
 	sd->passwd_state = OFONO_SIM_PASSWORD_NONE;
 	sd->sim_registered = FALSE;
 
+	current_sim = sim;
+
 	ofono_sim_set_data(sim, sd);
 
         /*
@@ -990,4 +995,9 @@ struct ofono_sim_driver *get_sim_driver()
 struct ofono_sim *get_sim()
 {
 	return current_sim;
+}
+
+gint ril_get_app_type()
+{
+	return current_active_app;
 }


### PR DESCRIPTION
Fixed merging bug with canonical version. Rilutil did not store the
SIM application type which lead to contacts importing failure.

Signed-off-by: Jussi Kangas jussi.kangas@oss.tieto.com
