### PR TITLE
Request for configuring main branch to start using multiclient ril

### DIFF
--- a/ofono/gril/ril_subscription.conf
+++ b/ofono/gril/ril_subscription.conf
@@ -5,5 +5,5 @@
 # - SUB1 (sub=SUB1)
 # - SUB2 (sub=SUB2)
 
-#[sub]
-#sub=SUB1
+[sub]
+sub=SUB1


### PR DESCRIPTION
Changes the flag in gril to enable rilmodem to support multiclient ril.
Warning: must be taken in use in sync with correct ril and libril
binaries

Signed-off-by: Jussi Kangas jussi.kangas@oss.tieto.com
