### PR TITLE
Request for pulling hidden reset support to main branch 

### DIFF
--- a/ofono/drivers/rilmodem/sim.c
+++ b/ofono/drivers/rilmodem/sim.c
@@ -106,6 +106,9 @@ struct sim_data {
 	enum ofono_sim_password_type passwd_state;
 };
 
+static void ril_pin_change_state_cb(struct ril_msg *message,
+			gpointer user_data);
+
 static void set_path(struct sim_data *sd, struct parcel *rilp,
 			const int fileid, const guchar *path,
 			const guint path_len)
@@ -543,8 +546,6 @@ static void configure_active_app(struct sim_data *sd,
 					struct sim_app *app,
 					guint index)
 {
-	size_t aid_size = 0, app_size = 0;
-
 	sd->app_type = app->app_type;
 	sd->aid_str = g_strdup(app->aid_str);
 	sd->app_str = g_strdup(app->app_str);
@@ -591,6 +592,7 @@ static void configure_active_app(struct sim_data *sd,
 			sd->passwd_state = OFONO_SIM_PASSWORD_PHFSIM_PUK;
 			break;
 		default:
+			sd->passwd_state = OFONO_SIM_PASSWORD_NONE;
 			break;
 		};
 		break;
@@ -613,6 +615,7 @@ static void sim_status_cb(struct ril_msg *message, gpointer user_data)
 	struct sim_status status;
 	guint i = 0;
 	guint search_index = -1;
+	struct parcel rilp;
 
 	DBG("");
 
@@ -648,9 +651,58 @@ static void sim_status_cb(struct ril_msg *message, gpointer user_data)
 			 * more appropriate call here??
 			 * __ofono_sim_refresh(sim, NULL, TRUE, TRUE);
 			 */
+			ofono_sim_inserted_notify(sim, TRUE);
+
+		if (current_passwd) {
+			if (!strcmp(current_passwd, defaultpasswd)) {
 			__ofono_sim_recheck_pin(sim);
+			} else if (sd->passwd_state !=
+						OFONO_SIM_PASSWORD_SIM_PIN) {
+				__ofono_sim_recheck_pin(sim);
+			} else if (sd->passwd_state ==
+						OFONO_SIM_PASSWORD_SIM_PIN) {
+				parcel_init(&rilp);
+
+				parcel_w_int32(&rilp,
+					ENTER_SIM_PIN_PARAMS);
+				parcel_w_string(&rilp, current_passwd);
+				parcel_w_string(&rilp, sd->aid_str);
+
+				g_ril_send(sd->ril,
+						RIL_REQUEST_ENTER_SIM_PIN,
+						rilp.data, rilp.size, NULL,
+						NULL, g_free);
+
+				parcel_free(&rilp);
+			}
+		} else {
+			__ofono_sim_recheck_pin(sim);
+		}
+
+		if (current_online_state == RIL_ONLINE_PREF) {
+
+			parcel_init(&rilp);
+
+			parcel_init(&rilp);
+			parcel_w_int32(&rilp, 1);
+			parcel_w_int32(&rilp, 1);
+
+			g_ril_send(sd->ril,
+					RIL_REQUEST_RADIO_POWER,
+					rilp.data,
+					rilp.size,
+					NULL, NULL, g_free);
+
+			parcel_free(&rilp);
+
+			current_online_state = RIL_ONLINE;
+		}
 
 		ril_util_free_sim_apps(apps, status.num_apps);
+	} else {
+		if (current_online_state == RIL_ONLINE)
+			current_online_state = RIL_ONLINE_PREF;
+		ofono_sim_inserted_notify(sim, FALSE);
 	}
 
 	/* TODO: if no SIM present, handle emergency calling. */
@@ -729,8 +781,11 @@ static void ril_pin_change_state_cb(struct ril_msg *message, gpointer user_data)
 		CALLBACK_WITH_SUCCESS(cb, cbd->data);
 		g_ril_print_response_no_args(sd->ril, message);
 
-	} else
+	} else {
+		if (current_passwd)
+			g_stpcpy(current_passwd, defaultpasswd);
 		CALLBACK_WITH_FAILURE(cb, cbd->data);
+	}
 
 }
 
@@ -745,6 +800,9 @@ static void ril_pin_send(struct ofono_sim *sim, const char *passwd,
 
 	sd->passwd_type = OFONO_SIM_PASSWORD_SIM_PIN;
 	cbd->user = sd;
+
+	if (current_passwd)
+		g_stpcpy(current_passwd, passwd);
 
 	parcel_init(&rilp);
 
@@ -791,6 +849,8 @@ static void ril_pin_change_state(struct ofono_sim *sim,
 	 */
 	switch (passwd_type) {
 	case OFONO_SIM_PASSWORD_SIM_PIN:
+		if (current_passwd)
+			g_stpcpy(current_passwd, passwd);
 		g_ril_append_print_buf(sd->ril, "(SC,");
 		parcel_w_string(&rilp, "SC");
 		break;
@@ -872,6 +932,9 @@ static void ril_pin_send_puk(struct ofono_sim *sim,
 	sd->passwd_type = OFONO_SIM_PASSWORD_SIM_PUK;
 	cbd->user = sd;
 
+	if (current_passwd)
+		g_stpcpy(current_passwd, passwd);
+
 	parcel_init(&rilp);
 
 	parcel_w_int32(&rilp, ENTER_SIM_PUK_PARAMS);
@@ -920,6 +983,8 @@ static void ril_change_passwd(struct ofono_sim *sim,
 
 	if (passwd_type == OFONO_SIM_PASSWORD_SIM_PIN2)
 		request = RIL_REQUEST_CHANGE_SIM_PIN2;
+	else if (current_passwd)
+		g_stpcpy(current_passwd, new_passwd);
 
 	ret = g_ril_send(sd->ril, request, rilp.data, rilp.size,
 			ril_pin_change_state_cb, cbd, g_free);

--- a/ofono/gril/gril.c
+++ b/ofono/gril/gril.c
@@ -867,6 +867,11 @@ static struct ril_s *create_ril()
 		g_strfreev(subscriptions);
 	}
 
+	current_passwd = g_try_malloc(16);
+	if (current_passwd)
+		g_stpcpy(current_passwd, defaultpasswd);
+	current_online_state = RIL_OFFLINE;
+
 	return ril;
 
 error:

--- a/ofono/gril/gril.h
+++ b/ofono/gril/gril.h
@@ -138,6 +138,9 @@ guint g_ril_register(GRil *ril, const int req,
 gboolean g_ril_unregister(GRil *ril, guint id);
 gboolean g_ril_unregister_all(GRil *ril);
 
+gchar *current_passwd;
+guint current_online_state;
+
 #ifdef __cplusplus
 }
 #endif

--- a/ofono/gril/grilutil.h
+++ b/ofono/gril/grilutil.h
@@ -31,6 +31,14 @@ extern "C" {
 #include "parcel.h"
 #include "gril.h"
 
+enum online_states {
+	RIL_OFFLINE,
+	RIL_ONLINE_PREF,
+	RIL_ONLINE,
+};
+
+static const char defaultpasswd[] = "NOTGIVEN";
+
 const char *ril_ofono_protocol_to_ril_string(guint protocol);
 int ril_protocol_string_to_ofono_protocol(gchar *protocol_str);
 const char *ril_appstate_to_string(int app_state);

--- a/ofono/plugins/ril.c
+++ b/ofono/plugins/ril.c
@@ -170,8 +170,10 @@ static void sim_status_cb(struct ril_msg *message, gpointer user_data)
 
 			ril->have_sim = TRUE;
 			power_on(modem);
-		} else
+		} else {
 			ofono_warn("No SIM card present.");
+			ofono_modem_set_powered(modem, TRUE);
+	}
 	}
 	/* TODO: handle emergency calls if SIM !present or locked */
 }
@@ -312,6 +314,11 @@ static void ril_set_online(struct ofono_modem *modem, ofono_bool_t online,
 	if (ret <= 0) {
 		g_free(cbd);
 		CALLBACK_WITH_FAILURE(callback, data);
+	} else {
+		if (online)
+			current_online_state = RIL_ONLINE_PREF;
+		else
+			current_online_state = RIL_OFFLINE;
 	}
 }
 
@@ -468,6 +475,8 @@ static int ril_init(void)
 static void ril_exit(void)
 {
 	DBG("");
+	if (current_passwd)
+		g_free(current_passwd);
 	ofono_modem_driver_unregister(&ril_driver);
 }
 


### PR DESCRIPTION
Hidden reset here means storing the PIN and givin it to modem without
user knowledge if modem reboots without power down. It also means
bringing up the interfaces back.

Signed-off-by: Jussi Kangas jussi.kangas@oss.tieto.com
