### PR TITLE
Request for pulling the gprs state query in all network state change situations to main branch

### DIFF
--- a/ofono/drivers/rilmodem/gprs.c
+++ b/ofono/drivers/rilmodem/gprs.c
@@ -78,12 +78,11 @@ static void ril_gprs_state_change(struct ril_msg *message, gpointer user_data)
 
 	g_assert(message->req == RIL_UNSOL_RESPONSE_VOICE_NETWORK_STATE_CHANGED);
 
-	/*
-	 * We are just want to track network data status change if ofono
-	 * itself is attached, so we avoid unnecessary data state requests.
-	 */
-	if (gd->ofono_attached == TRUE)
-		ril_gprs_registration_status(gprs, NULL, NULL);
+	/* We need to notify core always to cover situations when
+	 * connection drops temporarily for example when user is
+	 * taking CS voice call from LTE or changing technology
+	 * preference */
+	ril_gprs_registration_status(gprs, NULL, NULL);
 }
 
 static void ril_gprs_set_pref_network_cb(struct ril_msg *message,


### PR DESCRIPTION
Status needs to be always also asked regardless of the core attached
state. Otherwise temporary loss of the connection requires connman
API client to re-establish the connection regardless of the actual
modem state

Signed-off-by: Jussi Kangas jussi.kangas@oss.tieto.com
