### PR TITLE
sim: fix ofono crash when pin is blocked

### DIFF
--- a/ofono/src/sim.c
+++ b/ofono/src/sim.c
@@ -2763,11 +2763,11 @@ static void sim_pin_query_cb(const struct ofono_error *error,
 		break;
 	default:
 		if (sim->state == OFONO_SIM_STATE_READY) {
-			/* Force the sim state out of READY */
-			sim_free_main_state(sim);
 
 			sim->state = OFONO_SIM_STATE_LOCKED_OUT;
 			call_state_watches(sim);
+
+			sim_free_main_state(sim);
 		}
 		break;
 	}


### PR DESCRIPTION
Signed-off-by: Jarko Poutiainen Jarko.Poutiainen@oss.tieto.com

spn_watch is removed at sim_free_main_state when SIM PIN is blocked and due to this oFono will crash when network atom is removed because it will try to remove sim spn watch. This patch will fix above mentioned problem. There's already discussion regarding this in https://lists.ofono.org/pipermail/ofono/2013-September/015098.html
