### PR TITLE
Request for pulling checking the network status based on SPDI check in rilmodem to main branch

### DIFF
--- a/ofono/drivers/rilmodem/gprs.c
+++ b/ofono/drivers/rilmodem/gprs.c
@@ -44,6 +44,8 @@
 #include "common.h"
 #include "rilmodem.h"
 
+#include <ofono/netreg.h>
+
 /*
  * This module is the ofono_gprs_driver implementation for rilmodem.
  *
@@ -178,7 +180,10 @@ static void ril_data_reg_cb(struct ril_msg *message, gpointer user_data)
 		ofono_gprs_set_cid_range(gprs, 1, max_cids);
 	}
 
-	DBG("status is %d", status);
+	DBG("data registration status is %d", status);
+
+	if (status == NETWORK_REGISTRATION_STATUS_ROAMING)
+		status = check_if_really_roaming(status);
 
 	if (gd->ofono_attached && !gd->notified) {
 		if (status == NETWORK_REGISTRATION_STATUS_ROAMING ||
@@ -216,7 +221,7 @@ static void ril_data_reg_cb(struct ril_msg *message, gpointer user_data)
 		 * active in roaming situation and client closes
 		 * it directly by calling RoamingAllowed in API
 		 */
-		DBG("status is %d", status);
+		DBG("data registration status is %d", status);
 
 		if (status != NETWORK_REGISTRATION_STATUS_SEARCHING) {
 			DBG("ofono not attached, notify core");

--- a/ofono/drivers/rilmodem/rilutil.h
+++ b/ofono/drivers/rilmodem/rilutil.h
@@ -144,6 +144,8 @@ struct ofono_sim_driver *get_sim_driver();
 
 struct ofono_sim *get_sim();
 
+gint check_if_really_roaming(gint status);
+
 void ril_util_free_sim_apps(struct sim_app **apps, guint num_apps);
 
 struct cb_data {

--- a/ofono/include/netreg.h
+++ b/ofono/include/netreg.h
@@ -114,6 +114,7 @@ int ofono_netreg_get_status(struct ofono_netreg *netreg);
 int ofono_netreg_get_technology(struct ofono_netreg *netreg);
 const char *ofono_netreg_get_mcc(struct ofono_netreg *netreg);
 const char *ofono_netreg_get_mnc(struct ofono_netreg *netreg);
+struct sim_spdi *ofono_netreg_get_spdi(struct ofono_netreg *netreg);
 
 #ifdef __cplusplus
 }

--- a/ofono/src/network.c
+++ b/ofono/src/network.c
@@ -1732,6 +1732,17 @@ const char *ofono_netreg_get_mnc(struct ofono_netreg *netreg)
 	return netreg->current_operator->mnc;
 }
 
+struct sim_spdi *ofono_netreg_get_spdi(struct ofono_netreg *netreg)
+{
+	if (netreg == NULL)
+		return NULL;
+
+	if (netreg->spdi == NULL)
+		return NULL;
+
+	return netreg->spdi;
+}
+
 int ofono_netreg_driver_register(const struct ofono_netreg_driver *d)
 {
 	DBG("driver: %p, name: %s", d, d->name);


### PR DESCRIPTION
In case of virtual operators it looks like it is possible that
modem is indicating roaming state even though that is not true.
With this fix status is double checked against EF SPDI.

Signed-off-by: Jussi Kangas jussi.kangas@oss.tieto.com
