### PR TITLE
Request for pulling setting correct callback data in both manual and automatic network selections to main branch

### DIFF
--- a/ofono/drivers/rilmodem/network-registration.c
+++ b/ofono/drivers/rilmodem/network-registration.c
@@ -424,6 +424,9 @@ static void ril_register_manual(struct ofono_netreg *netreg,
 	int request = RIL_REQUEST_SET_NETWORK_SELECTION_MANUAL;
 	int ret;
 
+	/* add *netreg_data to callback */
+	cbd->user = nd;
+
 	parcel_init(&rilp);
 
 	/* RIL expects a char * specifying MCCMNC of network to select */


### PR DESCRIPTION
This is based on commit 3b18c7773460b6156b68411795a4ceb0dad4725e
from Tony Espy in Canonical. Without setting the netreg value both
in manual and automatic network selection request ofono crashes
when selecting manual and then automatic selection.

Signed-off-by: Jussi Kangas jussi.kangas@oss.tieto.com
