### PR TITLE
Request for pulling searching state hiding only if already notified registered to main branch

### DIFF
--- a/ofono/drivers/rilmodem/gprs.c
+++ b/ofono/drivers/rilmodem/gprs.c
@@ -222,7 +222,7 @@ static void ril_data_reg_cb(struct ril_msg *message, gpointer user_data)
 		if (gd->registerid != -1)
 			g_ril_unregister(gd->ril, gd->registerid);
 		gd->registerid = -1;
-	} else {
+	} else if (gd->notified) {
 		/*
 		 * Client is not approving succesful result
 		 * This covers the situation when context is


### PR DESCRIPTION
Hiding searching status always might cause very rare case where very
brief voice call connection status change to something else than
registered might cause ofono core to force data connection down.
Since connection down is not immediate but status can change right
away back that causes situation where response for outdated deattach
request overrides the return to attached state.

Signed-off-by: Jussi Kangas jussi.kangas@oss.tieto.com
