### PR TITLE
[ofono] Make DTMF sending via rilmodem more robust

### DIFF
--- a/ofono/src/voicecall.c
+++ b/ofono/src/voicecall.c
@@ -3799,8 +3799,8 @@ static gboolean tone_request_run(gpointer user_data)
 	len = strcspn(entry->left, "pP");
 
 	if (len) {
-		if (len > 8) /* Arbitrary length limit per request */
-			len = 8;
+		if (len > 1) /* Arbitrary length limit per request */
+			len = 1; /* TODO fix this in driver */
 
 		/* Temporarily move the end of the string */
 		final = entry->left[len];


### PR DESCRIPTION
Loop DTMF requests via core, not via driver. Drop unused variables.

Signed-off-by: Martti Piirainen martti.piirainen@oss.tieto.com
