### PR TITLE
[gdbus] Fix crash when disconnecting from D-Bus

### DIFF
--- a/ofono/gdbus/watch.c
+++ b/ofono/gdbus/watch.c
@@ -524,6 +524,8 @@ static DBusHandlerResult message_filter(DBusConnection *connection,
 	dbus_message_get_args(message, NULL, DBUS_TYPE_STRING, &arg, DBUS_TYPE_INVALID);
 
 	/* Sender is always the owner */
+	if (sender == NULL)
+		return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
 
 	for (current = listeners; current != NULL; current = current->next) {
 		data = current->data;


### PR DESCRIPTION
Upstream commit:

From b4b4b35d0beac7340aed6da979f043dd1424a631 Mon Sep 17 00:00:00 2001
From: Luiz Augusto von Dentz luiz.von.dentz@intel.com
Date: Mon, 9 Sep 2013 11:25:12 +0300
Subject: [PATCH 01/25] gdbus/watch: Fix crash when disconnecting from D-Bus

When disconnecting from D-Bus a message could be recieved with no sender:
Invalid read of size 1
   at 0x4A09EE1: strcmp (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
   by 0x3B03C386B8: g_str_equal (in /usr/lib64/libglib-2.0.so.0.3600.3)
   by 0x4065D6: message_filter (watch.c:529)
   by 0x3B0700F9E5: dbus_connection_dispatch (in /usr/lib64/libdbus-1.so.3.7.4)
   by 0x4052E7: message_dispatch (mainloop.c:76)
   by 0x3B03C48962: ??? (in /usr/lib64/libglib-2.0.so.0.3600.3)
   by 0x3B03C47E05: g_main_context_dispatch (in /usr/lib64/libglib-2.0.so.0.3600.3)
   by 0x3B03C48157: ??? (in /usr/lib64/libglib-2.0.so.0.3600.3)
   by 0x3B03C48559: g_main_loop_run (in /usr/lib64/libglib-2.0.so.0.3600.3)
   by 0x4038C5: client_proxy_removed (test-gdbus-client.c:902)
   by 0x3B03C6B566: ??? (in /usr/lib64/libglib-2.0.so.0.3600.3)
   by 0x3B03C6B6E5: ??? (in /usr/lib64/libglib-2.0.so.0.3600.3)
 Address 0x0 is not stack'd, malloc'd or (recently) free'd
