### PR TITLE
[rilmodem] Queue DTMF requests in driver

### DIFF
--- a/ofono/src/voicecall.c
+++ b/ofono/src/voicecall.c
@@ -3799,8 +3799,8 @@ static gboolean tone_request_run(gpointer user_data)
 	len = strcspn(entry->left, "pP");
 
 	if (len) {
-		if (len > 1) /* Arbitrary length limit per request */
-			len = 1; /* TODO fix this in driver */
+		if (len > 8) /* Arbitrary length limit per request */
+			len = 8;
 
 		/* Temporarily move the end of the string */
 		final = entry->left[len];

--- a/ofono/test/test-dtmf
+++ b/ofono/test/test-dtmf
@@ -1,0 +1,30 @@
+#!/usr/bin/python
+
+import sys
+import dbus
+import time
+
+bus = dbus.SystemBus()
+
+manager = dbus.Interface(bus.get_object('org.ofono', '/'),
+						'org.ofono.Manager')
+
+modems = manager.GetModems()
+modem = modems[0][0]
+
+if (len(sys.argv) == 2):
+	modem = sys.argv[1]
+
+manager = dbus.Interface(bus.get_object('org.ofono', modem),
+						'org.ofono.VoiceCallManager')
+
+print "Play single tones from 0 to 9"
+zeroAscii = ord('0')
+for x in range(0, 9):
+	manager.SendTones(chr(zeroAscii + x))
+
+print "Play longer strings"
+manager.SendTones("123")
+manager.SendTones("1234567890*#p987")
+manager.SendTones("123")
+


### PR DESCRIPTION
Add all DTMF requests to a buffer in the rilmodem driver, and play them as fast as the RIL and modem are able to (i.e. the timing is decoupled from oFono core and D-Bus clients). Also reverts the core change temporarily done via 9aedea4e782c0e1d956acf963d9249301076142b, and adds a DTMF test script.

Signed-off-by: Martti Piirainen martti.piirainen@oss.tieto.com
