### PR TITLE
[gdbus] Handle dbus disconnect signal

### DIFF
--- a/ofono/gdbus/watch.c
+++ b/ofono/gdbus/watch.c
@@ -524,8 +524,6 @@ static DBusHandlerResult message_filter(DBusConnection *connection,
 	dbus_message_get_args(message, NULL, DBUS_TYPE_STRING, &arg, DBUS_TYPE_INVALID);
 
 	/* Sender is always the owner */
-	if (sender == NULL)
-		return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
 
 	for (current = listeners; current != NULL; current = current->next) {
 		data = current->data;
@@ -533,21 +531,19 @@ static DBusHandlerResult message_filter(DBusConnection *connection,
 		if (connection != data->connection)
 			continue;
 
-		if (data->owner && g_str_equal(sender, data->owner) == FALSE)
+		if (data->owner && g_strcmp0(sender, data->owner) != 0)
 			continue;
 
-		if (data->path && g_str_equal(path, data->path) == FALSE)
+		if (data->path && g_strcmp0(path, data->path) != 0)
 			continue;
 
-		if (data->interface && g_str_equal(iface,
-						data->interface) == FALSE)
+		if (data->interface && g_strcmp0(iface, data->interface) != 0)
 			continue;
 
-		if (data->member && g_str_equal(member, data->member) == FALSE)
+		if (data->member && g_strcmp0(member, data->member) != 0)
 			continue;
 
-		if (data->argument && g_str_equal(arg,
-						data->argument) == FALSE)
+		if (data->argument && g_strcmp0(arg, data->argument) != 0)
 			continue;
 
 		if (data->handle_func) {


### PR DESCRIPTION
A previous patch stopped ofono from crashing when it received the disconnect signal (which has no sender). However this wasn't enough. gdbus/mainloop.c actually registers a listener for the disconnect signal, so message_filter should dispatch it.

This patch makes sure of that, and hardens message_filter's loop against any other fields which might be NULL. (the logic: if the data-> field is NULL it means don't filter on that value; if the message field is NULL then only match data structs that have that field NULL.)

Without this patch, if dbus is restarted ofonod will hang around and be useless until the next reboot.
