### PR TITLE
Request for pulling mcc and mnc presence check before spdi search to main branch

### DIFF
--- a/ofono/drivers/rilmodem/network-registration.c
+++ b/ofono/drivers/rilmodem/network-registration.c
@@ -559,7 +559,7 @@ gint check_if_really_roaming(gint status)
 	const char *net_mnc = ofono_netreg_get_mnc(current_netreg);
 	struct sim_spdi *spdi = ofono_netreg_get_spdi(current_netreg);
 
-	if (spdi) {
+	if (spdi && net_mcc && net_mnc) {
 		if (sim_spdi_lookup(spdi, net_mcc, net_mnc))
 			return NETWORK_REGISTRATION_STATUS_REGISTERED;
 		else


### PR DESCRIPTION
It is possible that network is received before current operator
is retrieved. In rare occasions this causes crash when tried
to compare mnc and mcc of current operator to spdi.

Signed-off-by: Jussi Kangas jussi.kangas@oss.tieto.com
