### PR TITLE
Request for pulling operator name numeric value check to main branch

### DIFF
--- a/ofono/drivers/rilmodem/network-registration.c
+++ b/ofono/drivers/rilmodem/network-registration.c
@@ -224,7 +224,10 @@ static void ril_cops_cb(struct ril_msg *message, gpointer user_data)
 	else
 		goto error;
 
-	extract_mcc_mnc(numeric, op.mcc, op.mnc);
+	if (numeric)
+		extract_mcc_mnc(numeric, op.mcc, op.mnc);
+	else
+		goto error;
 
 	/* Set to current */
 	op.status = OPERATOR_STATUS_CURRENT;


### PR DESCRIPTION
According to ril.h numeric value can be null in response to
RIL_REQUEST_OPERATOR. That means phone is unregistered and
current operator should return error

Signed-off-by: Jussi Kangas jussi.kangas@oss.tieto.com
