### PR TITLE
Next: Handle 1) gril connect fail at startup 2) gril hangup when already up

### DIFF
--- a/ofono/gril/gril.c
+++ b/ofono/gril/gril.c
@@ -908,8 +908,7 @@ static struct ril_s *create_ril()
 	return ril;
 
 error:
-	ofono_error("Exiting...");
-	exit(EXIT_FAILURE);
+	return NULL;
 }
 
 static struct ril_notify *ril_notify_create(struct ril_s *ril,


### PR DESCRIPTION
First commit implements the gril disconnect callback to notify rilplugin if ril connection hangs up (or is killed)
Second commit improves the solution by restarting rilmodem instead of exiting ofono
