### PR TITLE
Request for pulling storing the configuration info to ofono storage directory to next branch

### DIFF
--- a/ofono/drivers/rilmodem/rilmodem.h
+++ b/ofono/drivers/rilmodem/rilmodem.h
@@ -28,6 +28,7 @@
 #define EF_STATUS_INVALIDATED 0
 #define EF_STATUS_VALID 1
 #define RIL_CONFIG "/etc/ofono/ril_subscription.conf"
+#define RIL_STORE "rilmodem"
 #define LTE_FLAG "4gOn"
 
 extern void ril_devinfo_init(void);


### PR DESCRIPTION
Information if the configuration has been done or not cannot be
stored to same file where configuration is read from due the lack
of priviledges. This change makes ofono to store the information
to same place as any other setting stored by ofono.

Signed-off-by: Jussi Kangas jussi.kangas@oss.tieto.com
