### PR TITLE
[rilmodem] Remove unnecessary 'fake' held status when dialing 2nd call

### DIFF
--- a/ofono/drivers/rilmodem/voicecall.c
+++ b/ofono/drivers/rilmodem/voicecall.c
@@ -316,17 +316,6 @@ static void rild_cb(struct ril_msg *message, gpointer user_data)
 
 	g_ril_print_response_no_args(vd->ril, message);
 
-	/* On a success, make sure to put all active calls on hold */
-	for (l = vd->calls; l; l = l->next) {
-		call = l->data;
-
-		if (call->status != CALL_STATUS_ACTIVE)
-			continue;
-
-		call->status = CALL_STATUS_HELD;
-		ofono_voicecall_notify(vc, call);
-	}
-
 	/* CLCC will update the oFono call list with proper ids  */
 	if (!vd->clcc_source)
 		vd->clcc_source = g_timeout_add(POLL_CLCC_INTERVAL,


### PR DESCRIPTION
There is no need to indicate a status change to "held" before getting an actual state change from the modem - and sometimes this led to wrong status indications.

Signed-off-by: Martti Piirainen martti.piirainen@oss.tieto.com
