### PR TITLE
Request for pulling modem name freezing to main branch

### DIFF
--- a/ofono/plugins/ril.c
+++ b/ofono/plugins/ril.c
@@ -567,7 +567,7 @@ static int ril_init(void)
 	 *
 	 * args are name (optional) & type
 	 */
-	modem = ofono_modem_create(NULL, "ril");
+	modem = ofono_modem_create("ril_0", "ril");
 	if (modem == NULL) {
 		DBG("ofono_modem_create failed for ril");
 		return -ENODEV;


### PR DESCRIPTION
Silent restarting of rilmodem without killing ofono  when rild dies
causes ril modem id to increase. This might cause problems if
clients are not reading the modem id. Since this modem id increase
is unnecessary at the moment ( we are not supporting multiple
modems ) removal of id increase is recommendable as precaution.

Signed-off-by: Jussi Kangas jussi.kangas@oss.tieto.com
