### PR TITLE
Use "internet" apn for auto-created context

### DIFF
--- a/ofono/src/gprs.c
+++ b/ofono/src/gprs.c
@@ -2992,8 +2992,15 @@ static void ofono_gprs_finish_register(struct ofono_gprs *gprs)
 	struct ofono_modem *modem = __ofono_atom_get_modem(gprs->atom);
 	const char *path = __ofono_atom_get_path(gprs->atom);
 
-	if (gprs->contexts == NULL) /* Automatic provisioning failed */
-		add_context(gprs, NULL, OFONO_GPRS_CONTEXT_TYPE_INTERNET);
+	if (gprs->contexts == NULL) {
+		/* Automatic provisioning failed */
+		struct pri_context *context = add_context(gprs, NULL,
+					OFONO_GPRS_CONTEXT_TYPE_INTERNET);
+		if (context) {
+			strcpy(context->context.apn, "internet");
+		}
+		/* Should MMS context be created as well? */
+	}
 
 	if (!g_dbus_register_interface(conn, path,
 					OFONO_CONNECTION_MANAGER_INTERFACE,


### PR DESCRIPTION
Such an access point has a pretty good chance to actually work.
About 15% of all GPRS Internet access points in the world are
named "internet" and have no user name or password. It's by far
the most common use case.
