### PR TITLE
[build] Fix network time plugin build issues

### DIFF
--- a/ofono/Makefile.am
+++ b/ofono/Makefile.am
@@ -508,6 +508,7 @@ endif
 if NETTIME
 builtin_modules += nettime
 builtin_sources += plugins/nettime.c
+builtin_libadd += -lrt
 endif
 
 if PROVISION

--- a/ofono/configure.ac
+++ b/ofono/configure.ac
@@ -192,7 +192,7 @@ AM_CONDITIONAL(BLUETOOTH, test "${enable_bluetooth}" != "no")
 AC_ARG_ENABLE(nettime, AC_HELP_STRING([--disable-nettime],
                                 [disable Nettime plugin]),
                                         [enable_nettime=${enableval}])
-AM_CONDITIONAL(NETTIME, test "${enable_netttime}" != "no")
+AM_CONDITIONAL(NETTIME, test "${enable_nettime}" != "no")
 
 AC_ARG_WITH([provisiondb], AC_HELP_STRING([--with-provisiondb=FILE],
 	[location of provision database]), [path_provisiondb=${withval}])


### PR DESCRIPTION
The network time plugin needs the POSIX realtime lib, and in some compilation environments this needs to be explicitly linked. Also, there was a typo that broke the '--disable-nettime' configure option.

Signed-off-by: Martti Piirainen martti.piirainen@oss.tieto.com
