### PR TITLE
[build] Fix network time plugin build issues

### DIFF
--- a/ofono/configure.ac
+++ b/ofono/configure.ac
@@ -192,7 +192,10 @@ AM_CONDITIONAL(BLUETOOTH, test "${enable_bluetooth}" != "no")
 AC_ARG_ENABLE(nettime, AC_HELP_STRING([--disable-nettime],
                                 [disable Nettime plugin]),
                                         [enable_nettime=${enableval}])
-AM_CONDITIONAL(NETTIME, test "${enable_netttime}" != "no")
+if (test "${enable_nettime}" != "no"); then
+	AC_SEARCH_LIBS([clock_gettime], [rt])
+fi
+AM_CONDITIONAL(NETTIME, test "${enable_nettime}" != "no")
 
 AC_ARG_WITH([provisiondb], AC_HELP_STRING([--with-provisiondb=FILE],
 	[location of provision database]), [path_provisiondb=${withval}])


### PR DESCRIPTION
Link clock functions explicitly to the POSIX realtime library when using glibc version < 2.17 (otherwise, some compilation environments implicitly link libpthread, others fail). Also, there was a typo that broke the '--disable-nettime' configure option.

Signed-off-by: Martti Piirainen martti.piirainen@oss.tieto.com
