### PR TITLE
[init] Added boot-time requirement to be started after dbus service

### DIFF
--- a/ofono/src/ofono.service.in
+++ b/ofono/src/ofono.service.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=Telephony service
-After=syslog.target
+Requires=dbus.service
+After=dbus.service
 
 [Service]
 Type=dbus


### PR DESCRIPTION
Ofono daemon crashes during shutdown if dbus daemon exits before ofono.
This change makes sure dbus is started before ofono and stopped after ofono.

Signed-off-by: Pekka Lundstrom pekka.lundstrom@jollamobile.com
