### PR TITLE
[gril] Fix 'unused variable' compiler warning

### DIFF
--- a/ofono/gril/gril.c
+++ b/ofono/gril/gril.c
@@ -418,7 +418,6 @@ static void handle_unsol_req(struct ril_s *p, struct ril_msg *message)
 	int req_key;
 	gpointer key, value;
 	GSList *list_item;
-	struct ril_notify_node *node;
 	gboolean found = FALSE;
 
 	if (p->notify_list == NULL)


### PR DESCRIPTION
Signed-off-by: Martti Piirainen martti.piirainen@oss.tieto.com

Warning was accidentally introduced in PR#170.
