### PR TITLE
Make the push-forwarder plugin configurable

### DIFF
--- a/ofono/Makefile.am
+++ b/ofono/Makefile.am
@@ -549,10 +549,12 @@ builtin_sources += plugins/smart-messaging.c
 builtin_modules += push_notification
 builtin_sources += plugins/push-notification.c
 
+if PUSHFORWARDER
 builtin_modules += push_forwarder
 builtin_sources += plugins/push-forwarder.c
 builtin_cflags += @WSPCODEC_CFLAGS@
 builtin_libadd += @WSPCODEC_LIBS@
+endif
 
 builtin_modules += sms_history
 builtin_sources += plugins/smshistory.c

--- a/ofono/configure.ac
+++ b/ofono/configure.ac
@@ -231,6 +231,11 @@ AC_ARG_ENABLE(datafiles, AC_HELP_STRING([--disable-datafiles],
 					[enable_datafiles=${enableval}])
 AM_CONDITIONAL(DATAFILES, test "${enable_datafiles}" != "no")
 
+AC_ARG_ENABLE(pushforwarder, AC_HELP_STRING([--disable-pushforwarder],
+                                [disable Push Forwarder plugin]),
+                                        [enable_pushforwarder=${enableval}])
+AM_CONDITIONAL(PUSHFORWARDER, test "${enable_pushforwarder}" != "no")
+
 if (test "${prefix}" = "NONE"); then
 	dnl no prefix and no localstatedir, so default to /var
 	if (test "$localstatedir" = '${prefix}/var'); then


### PR DESCRIPTION
Enable removing the push-forwarder plugin (and its dependency to libwspcodec) via a '--disable-pushforwarder' configure option. The plugin is still enabled by default.
