### PR TITLE
Request for pulling checking of voice network status if data reg status is searching to next branch

### DIFF
--- a/ofono/drivers/rilmodem/gprs.c
+++ b/ofono/drivers/rilmodem/gprs.c
@@ -237,7 +237,7 @@ static void ril_data_reg_cb(struct ril_msg *message, gpointer user_data)
 			ofono_gprs_detached_notify(gprs);
 			gd->notified = FALSE;
 			gd->ofono_attached = FALSE;
-		} else if (gd->notified) {
+		} else if (gd->notified && check_if_really_searching()) {
 			DBG("hide the searching state");
 			status = NETWORK_REGISTRATION_STATUS_REGISTERED;
 			ofono_gprs_status_notify(gprs, status);

--- a/ofono/drivers/rilmodem/network-registration.c
+++ b/ofono/drivers/rilmodem/network-registration.c
@@ -573,6 +573,15 @@ error:
 	ofono_error("Unable to notify ofono about nitz");
 }
 
+gboolean check_if_really_searching()
+{
+	int status = NETWORK_REGISTRATION_STATUS_SEARCHING;
+	status = ofono_netreg_get_status(current_netreg);
+	if (status == NETWORK_REGISTRATION_STATUS_SEARCHING)
+		return TRUE;
+	return FALSE;
+}
+
 gint check_if_really_roaming(gint status)
 {
 	const char *net_mcc = ofono_netreg_get_mcc(current_netreg);

--- a/ofono/drivers/rilmodem/rilutil.h
+++ b/ofono/drivers/rilmodem/rilutil.h
@@ -123,6 +123,8 @@ struct ofono_sim *get_sim();
 
 gint check_if_really_roaming(gint status);
 
+gboolean check_if_really_searching();
+
 void ril_util_free_sim_apps(struct sim_app **apps, guint num_apps);
 
 struct cb_data {


### PR DESCRIPTION
...ng

If connection drops to searching and only voice call registration
status changes to roaming, with current implementation it is possible
to get through roaming allowed check in core. This prevents it.

Signed-off-by: Jussi Kangas jussi.kangas@oss.tieto.com
