### PR TITLE
[ofono][dundee] At startup order dundee after dbus instead of syslog.

### DIFF
--- a/ofono/dundee/dundee.service.in
+++ b/ofono/dundee/dundee.service.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=DUN service
-After=syslog.target
+Requires=dbus.service
+After=dbus.service
 
 [Service]
 Type=dbus


### PR DESCRIPTION
According to systemd documentation
"Newer systemd versions (v35+) do not support non-socket-activated syslog
daemons anymore and we do no longer recommend people to order their units
after syslog.target."

Signed-off-by: Tommi Kenakkala tommi.kenakkala@oss.tieto.com
