### PR TITLE
[RILMODEM] fix cf query callback list handling

### DIFF
--- a/ofono/drivers/rilmodem/call-forwarding.c
+++ b/ofono/drivers/rilmodem/call-forwarding.c
@@ -235,9 +235,8 @@ static void ril_query_cb(struct ril_msg *message, gpointer user_data)
 				list[i].phone_number.number[
 					OFONO_MAX_PHONE_NUMBER_LENGTH] = '\0';
 
-				list[i].time = parcel_r_int32(&rilp);
 			}
-
+			list[i].time = parcel_r_int32(&rilp);
 		}
 
 		CALLBACK_WITH_SUCCESS(cb, nmbr_of_resps, list, cbd->data);


### PR DESCRIPTION
if cf query callback received a list with more than one response and at least one of them without phone number and at least one was not the last item in the list the parsing of the list lead to indeterminate behaviour regarding the list handling.

Signed-off-by: Jarko Poutiainen Jarko.Poutiainen@oss.tieto.com
