### PR TITLE
[voicecall] Inform client when local ringback tone is needed

### DIFF
--- a/ofono/Makefile.am
+++ b/ofono/Makefile.am
@@ -587,7 +587,7 @@ src_ofonod_SOURCES = $(builtin_sources) src/ofono.ver \
 			src/cdma-provision.c src/handsfree.c \
 			src/handsfree-audio.c src/bluetooth.h \
 			src/hfp.h src/sim-mnclength.c src/oemraw.c \
-			src/siri.c
+			src/siri.c src/voicecallagent.c
 
 src_ofonod_LDADD = gdbus/libgdbus-internal.la $(builtin_libadd) \
 			@GLIB_LIBS@ @DBUS_LIBS@ -ldl
@@ -726,7 +726,8 @@ test_scripts = test/backtrace \
 		test/hangup-multiparty \
 		test/hangup-call \
 		test/display-icon \
-		test/set-msisdn
+		test/set-msisdn \
+		test/test-voicecallagent
 
 if TEST
 testdir = $(pkglibdir)/test

--- a/ofono/doc/voicecallmanager-api.txt
+++ b/ofono/doc/voicecallmanager-api.txt
@@ -198,6 +198,25 @@ Methods		dict GetProperties()
 					 [service].Error.InvalidFormat
 					 [service].Error.Failed
 
+		void RegisterVoicecallAgent(object path)
+
+			Registers an agent which will be called whenever a
+			specific voice call related event requiring a client
+			action occurs. Currently, the only such action is
+			playing a ringback tone locally.
+
+			Possible Errors: [service].Error.InProgress
+					 [service].Error.InvalidArguments
+					 [service].Error.InvalidFormat
+					 [service].Error.Failed
+
+		void UnregisterVoicecallAgent(object path)
+
+			Unregisters an agent.
+
+			Possible Errors: [service].Error.InvalidArguments
+					 [service].Error.Failed
+
 Signals		CallAdded(object path, dict properties)
 
 			Signal that is sent when a new call is added.  It
@@ -257,3 +276,26 @@ Properties	array{string} EmergencyNumbers [readonly]
 			of numbers provided by the specification and any
 			extra numbers provisioned by the carrier on the
 			SIM.
+
+VoiceCallAgent Hierarchy
+========================
+
+Service		unique name
+Interface	org.ofono.VoiceCallAgent
+Object path	freely definable
+
+Methods		void RingbackTone(boolean playTone)
+
+			Requests the client to generate an alerting tone locally
+			(3GPP 24.008; 5.2.1.5). This can happen when an outgoing
+			voice call is made and network is not providing the
+			alerting tone. Value 0 stands for "stop playing ringback
+			tone" and 1 for "start playing ringback tone".
+
+		void Release() [noreply]
+
+			Agent is being released, possibly because of oFono
+			terminating, voicecall interface is being torn down or
+			modem is switched off. No UnregisterVoicecallAgent
+			call is needed.
+

--- a/ofono/include/voicecall.h
+++ b/ofono/include/voicecall.h
@@ -3,6 +3,7 @@
  *  oFono - Open Source Telephony
  *
  *  Copyright (C) 2008-2011  Intel Corporation. All rights reserved.
+ *  Copyright (C) 2014 Jolla Ltd.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License version 2 as
@@ -170,6 +171,9 @@ void ofono_voicecall_ssn_mo_notify(struct ofono_voicecall *vc, unsigned int id,
 void ofono_voicecall_ssn_mt_notify(struct ofono_voicecall *vc, unsigned int id,
 					int code, int index,
 					const struct ofono_phone_number *ph);
+
+void ofono_voicecall_ringback_tone_notify(struct ofono_voicecall *vc,
+						const ofono_bool_t playTone);
 
 #ifdef __cplusplus
 }

--- a/ofono/src/ofono.conf
+++ b/ofono/src/ofono.conf
@@ -15,6 +15,7 @@
     <allow send_interface="org.ofono.SmartMessagingAgent"/>
     <allow send_interface="org.ofono.PositioningRequestAgent"/>
     <allow send_interface="org.ofono.HandsfreeAudioAgent"/>
+    <allow send_interface="org.ofono.VoiceCallAgent"/>
   </policy>
 
   <policy user="radio">
@@ -25,6 +26,7 @@
     <allow send_interface="org.ofono.SmartMessagingAgent"/>
     <allow send_interface="org.ofono.PositioningRequestAgent"/>
     <allow send_interface="org.ofono.HandsfreeAudioAgent"/>
+    <allow send_interface="org.ofono.VoiceCallAgent"/>
   </policy>
 
   <policy at_console="true">

--- a/ofono/src/voicecall.c
+++ b/ofono/src/voicecall.c
@@ -3,6 +3,7 @@
  *  oFono - Open Source Telephony
  *
  *  Copyright (C) 2008-2011  Intel Corporation. All rights reserved.
+ *  Copyright (C) 2014 Jolla Ltd.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License version 2 as
@@ -38,6 +39,7 @@
 #include "simutil.h"
 #include "smsutil.h"
 #include "storage.h"
+#include "voicecallagent.h"
 
 #define MAX_VOICE_CALLS 16
 
@@ -75,6 +77,7 @@ struct ofono_voicecall {
 	ofono_voicecall_cb_t release_queue_done_cb;
 	struct ofono_emulator *pending_em;
 	unsigned int pending_id;
+	struct voicecall_agent *vc_agent;
 };
 
 struct voicecall {
@@ -2140,6 +2143,72 @@ static DBusMessage *manager_get_calls(DBusConnection *conn,
 	return reply;
 }
 
+static void voicecall_agent_notify(gpointer user_data)
+{
+	struct ofono_voicecall *vc = user_data;
+	vc->vc_agent = NULL;
+}
+
+static DBusMessage *voicecall_register_agent(DBusConnection *conn,
+					DBusMessage *msg, void *data)
+{
+	struct ofono_voicecall *vc = data;
+	const char *agent_path;
+
+	if (vc->vc_agent)
+		return __ofono_error_busy(msg);
+
+	if (dbus_message_get_args(msg, NULL, DBUS_TYPE_OBJECT_PATH,
+				&agent_path, DBUS_TYPE_INVALID) == FALSE)
+		return __ofono_error_invalid_args(msg);
+
+	if (!__ofono_dbus_valid_object_path(agent_path))
+		return __ofono_error_invalid_format(msg);
+
+	vc->vc_agent = voicecall_agent_new(agent_path,
+						dbus_message_get_sender(msg));
+
+	if (vc->vc_agent == NULL)
+		return __ofono_error_failed(msg);
+
+	voicecall_agent_set_removed_notify(vc->vc_agent,
+			voicecall_agent_notify, vc);
+
+	return dbus_message_new_method_return(msg);
+}
+
+static DBusMessage *voicecall_unregister_agent(DBusConnection *conn,
+						DBusMessage *msg, void *data)
+{
+	struct ofono_voicecall *vc = data;
+	const char *agent_path;
+	const char *agent_bus = dbus_message_get_sender(msg);
+
+	if (dbus_message_get_args(msg, NULL, DBUS_TYPE_OBJECT_PATH, &agent_path,
+					DBUS_TYPE_INVALID) == FALSE)
+		return __ofono_error_invalid_args(msg);
+
+	if (vc->vc_agent == NULL)
+		return __ofono_error_failed(msg);
+
+	if (!voicecall_agent_matches(vc->vc_agent, agent_path, agent_bus))
+		return __ofono_error_access_denied(msg);
+
+	if (vc->vc_agent) {
+		voicecall_agent_free(vc->vc_agent);
+		vc->vc_agent = NULL;
+	}
+
+	return dbus_message_new_method_return(msg);
+}
+
+void ofono_voicecall_ringback_tone_notify(struct ofono_voicecall *vc,
+						const ofono_bool_t playTone)
+{
+	if (vc->vc_agent)
+		voicecall_agent_ringback_tone(vc->vc_agent, playTone);
+}
+
 static const GDBusMethodTable manager_methods[] = {
 	{ GDBUS_METHOD("GetProperties",
 			NULL, GDBUS_ARGS({ "properties", "a{sv}" }),
@@ -2172,6 +2241,12 @@ static const GDBusMethodTable manager_methods[] = {
 	{ GDBUS_METHOD("GetCalls",
 		NULL, GDBUS_ARGS({ "calls_with_properties", "a(oa{sv})" }),
 		manager_get_calls) },
+	{ GDBUS_ASYNC_METHOD("RegisterVoicecallAgent",
+				GDBUS_ARGS({ "path", "o" }), NULL,
+				voicecall_register_agent) },
+	{ GDBUS_ASYNC_METHOD("UnregisterVoicecallAgent",
+				GDBUS_ARGS({ "path", "o" }), NULL,
+				voicecall_unregister_agent) },
 	{ }
 };
 
@@ -2743,6 +2818,11 @@ static void voicecall_unregister(struct ofono_atom *atom)
 	emulator_hfp_unregister(atom);
 
 	voicecall_close_settings(vc);
+
+	if (vc->vc_agent) {
+		voicecall_agent_free(vc->vc_agent);
+		vc->vc_agent = 0;
+	}
 
 	if (vc->sim_state_watch) {
 		ofono_sim_remove_state_watch(vc->sim, vc->sim_state_watch);

--- a/ofono/src/voicecallagent.c
+++ b/ofono/src/voicecallagent.c
@@ -1,0 +1,131 @@
+/*
+ *
+ *  oFono - Open Source Telephony
+ *
+ *  Copyright (C) 2014 Jolla Ltd
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2 as
+ *  published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#include <glib.h>
+#include <gdbus.h>
+
+#include "ofono.h"
+#include "voicecallagent.h"
+
+#define OFONO_VOICECALL_AGENT_INTERFACE "org.ofono.VoiceCallAgent"
+
+struct voicecall_agent {
+	char *path;			/* Agent Path */
+	char *bus;			/* Agent bus */
+	guint disconnect_watch;		/* DBus disconnect watch */
+	ofono_destroy_func removed_cb;
+	void *removed_data;
+};
+
+void voicecall_agent_ringback_tone(struct voicecall_agent *agent,
+					const ofono_bool_t playTone)
+{
+	DBusConnection *conn = ofono_dbus_get_connection();
+	DBusMessage *message = dbus_message_new_method_call(
+			agent->bus, agent->path,
+			OFONO_VOICECALL_AGENT_INTERFACE,
+			"RingbackTone");
+
+	if (message == NULL)
+		return;
+
+	if (!dbus_message_append_args(message, DBUS_TYPE_BOOLEAN, &playTone,
+				DBUS_TYPE_INVALID))
+		return;
+
+	dbus_message_set_no_reply(message, TRUE);
+	g_dbus_send_message(conn, message);
+}
+
+void voicecall_agent_send_release(struct voicecall_agent *agent)
+{
+	DBusConnection *conn = ofono_dbus_get_connection();
+	DBusMessage *message = dbus_message_new_method_call(
+			agent->bus, agent->path,
+			OFONO_VOICECALL_AGENT_INTERFACE,
+			"Release");
+
+	if (message == NULL)
+		return;
+
+	dbus_message_set_no_reply(message, TRUE);
+	g_dbus_send_message(conn, message);
+}
+
+void voicecall_agent_set_removed_notify(struct voicecall_agent *agent,
+					ofono_destroy_func destroy,
+					void *user_data)
+{
+	agent->removed_cb = destroy;
+	agent->removed_data = user_data; /* voicecall atom (not owned) */
+}
+
+void voicecall_agent_free(struct voicecall_agent *agent)
+{
+	DBusConnection *conn = ofono_dbus_get_connection();
+
+	if (agent->disconnect_watch) {
+		voicecall_agent_send_release(agent);
+		g_dbus_remove_watch(conn, agent->disconnect_watch);
+		agent->disconnect_watch = 0;
+	}
+
+	if (agent->removed_cb)
+		agent->removed_cb(agent->removed_data);
+
+	g_free(agent->path);
+	g_free(agent->bus);
+	g_free(agent);
+}
+
+ofono_bool_t voicecall_agent_matches(struct voicecall_agent *agent,
+				const char *path, const char *sender)
+{
+	return g_str_equal(agent->path, path) &&
+			g_str_equal(agent->bus, sender);
+}
+
+void voicecall_agent_disconnect_cb(DBusConnection *conn, void *user_data)
+{
+	struct voicecall_agent *agent = user_data;
+
+	agent->disconnect_watch = 0;
+	voicecall_agent_free(agent);
+}
+
+struct voicecall_agent *voicecall_agent_new(const char *path,
+						const char *sender)
+{
+	struct voicecall_agent *agent = g_try_new0(struct voicecall_agent, 1);
+	DBusConnection *conn = ofono_dbus_get_connection();
+
+	if (agent == NULL)
+		return NULL;
+
+	agent->path = g_strdup(path);
+	agent->bus = g_strdup(sender);
+
+	agent->disconnect_watch = g_dbus_add_disconnect_watch(conn, sender,
+						voicecall_agent_disconnect_cb,
+						agent, NULL);
+
+	return agent;
+}

--- a/ofono/src/voicecallagent.h
+++ b/ofono/src/voicecallagent.h
@@ -1,0 +1,40 @@
+/*
+ *
+ *  oFono - Open Source Telephony
+ *
+ *  Copyright (C) 2014 Jolla Ltd
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2 as
+ *  published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+struct voicecall_agent;
+
+void voicecall_agent_ringback_tone(struct voicecall_agent *agent,
+					const ofono_bool_t playTone);
+
+void voicecall_agent_set_removed_notify(struct voicecall_agent *agent,
+					ofono_destroy_func removed_cb,
+					void *user_data);
+
+void voicecall_agent_free(struct voicecall_agent *agent);
+
+ofono_bool_t voicecall_agent_matches(struct voicecall_agent *agent,
+					const char *path, const char *sender);
+
+struct voicecall_agent *voicecall_agent_new(const char *path,
+						const char *sender);
+
+void voicecall_agent_disconnect_cb(DBusConnection *conn,
+		void *user_data);

--- a/ofono/test/test-voicecallagent
+++ b/ofono/test/test-voicecallagent
@@ -1,0 +1,48 @@
+#!/usr/bin/python
+
+import gobject
+
+import sys
+import dbus
+import dbus.service
+import dbus.mainloop.glib
+
+class VoiceCallAgent(dbus.service.Object):
+	@dbus.service.method("org.ofono.VoiceCallAgent",
+					in_signature="", out_signature="")
+	def Release(self):
+		print "Agent got Release"
+		mainloop.quit()
+
+	@dbus.service.method("org.ofono.VoiceCallAgent",
+				in_signature="b", out_signature="")
+	def RingbackTone(self, playTone):
+		print "Agent got playTone notification: %d" % playTone
+
+if __name__ == '__main__':
+	dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
+
+	bus = dbus.SystemBus()
+	manager = dbus.Interface(bus.get_object("org.ofono", "/"),
+							"org.ofono.Manager")
+
+	modems = manager.GetModems()
+
+	for path, properties in modems:
+		if "org.ofono.VoiceCallManager" not in properties["Interfaces"]:
+			continue
+
+		vcm = dbus.Interface(bus.get_object('org.ofono', path),
+					'org.ofono.VoiceCallManager')
+
+	path = "/test/agent"
+	agent = VoiceCallAgent(bus, path)
+	vcm.RegisterVoicecallAgent(agent)
+	print "Agent registered"
+	mainloop = gobject.MainLoop()
+
+	try:
+		mainloop.run()
+	except KeyboardInterrupt:
+		vcm.UnregisterVoicecallAgent(path)
+		print "Agent unregistered (interrupt)"

--- a/rpm/ofono.spec
+++ b/rpm/ofono.spec
@@ -101,7 +101,7 @@ systemctl daemon-reload ||:
 %files
 %defattr(-,root,root,-)
 %doc COPYING ChangeLog AUTHORS README
-%config(noreplace) %{_sysconfdir}/dbus-1/system.d/*.conf
+%config %{_sysconfdir}/dbus-1/system.d/*.conf
 %{_sbindir}/*
 /%{_lib}/systemd/system/network.target.wants/ofono.service
 /%{_lib}/systemd/system/ofono.service


### PR DESCRIPTION
In some networks, MO calls do not get the "alerting" tone in-band, so the device needs to play one locally.

This commit adds a "voice call agent" API - currently containing only the ringback tone notification but extendable later - and implements it in the rilmodem driver.
