### PR TITLE
[SRC] fix incorrect CF state after CFU erasure

### DIFF
--- a/ofono/src/call-forwarding.c
+++ b/ofono/src/call-forwarding.c
@@ -713,8 +713,12 @@ static DBusMessage *set_property_request(struct ofono_call_forwarding *cf,
 	if (ph->number[0] != '\0')
 		cf->driver->registration(cf, type, cls, ph, timeout,
 					set_property_callback, cf);
-	else
+	else {
+		if (cf->query_next == CALL_FORWARDING_TYPE_UNCONDITIONAL)
+			cf->query_end = CALL_FORWARDING_TYPE_NOT_REACHABLE;
+
 		cf->driver->erasure(cf, type, cls, set_property_callback, cf);
+	}
 
 	return NULL;
 }


### PR DESCRIPTION
If CFU is enabled while any or all of the conditional CF are in quiescent state when ofono is booted, ofono will return false state for all the conditional CF if CFU is disabled because only the CFU state is queried from the modem. This fix causes ofono to query all the conditional CF states in case of CFU erase.
Signed-off-by: Jarko Poutiainen Jarko.Poutiainen@oss.tieto.com
