### PR TITLE
[rilmodem] Null netreg pointer on netreg remove

### DIFF
--- a/ofono/drivers/rilmodem/network-registration.c
+++ b/ofono/drivers/rilmodem/network-registration.c
@@ -669,6 +669,7 @@ static void ril_netreg_remove(struct ofono_netreg *netreg)
 		g_source_remove(nd->nitz_timeout);
 
 	ofono_netreg_set_data(netreg, NULL);
+	current_netreg = NULL;
 
 	if (nd->timer_id > 0)
 		g_source_remove(nd->timer_id);


### PR DESCRIPTION
Netreg driver has a static copy of the netreg pointer.
Missing NULLing may cause problems on corner cases after
netreg is freed (when core atom is flushed).

Signed-off-by: Tommi Kenakkala tommi.kenakkala@oss.tieto.com
