### PR TITLE
[ofono] Encode SMS as UTF-16 instead of UCS-2

### DIFF
--- a/ofono/src/smsutil.c
+++ b/ofono/src/smsutil.c
@@ -3561,7 +3561,7 @@ GSList *sms_text_prepare_with_alphabet(const char *to, const char *utf8,
 	if (gsm_encoded == NULL) {
 		gsize converted;
 
-		ucs2_encoded = g_convert(utf8, -1, "UCS-2BE//TRANSLIT", "UTF-8",
+		ucs2_encoded = g_convert(utf8, -1, "UTF-16BE//TRANSLIT", "UTF-8",
 						NULL, &converted, NULL);
 		written = converted;
 	}


### PR DESCRIPTION
UCS-2 is an older 16-bit encoding compatible with the unicode BMP.
UTF-16 extends UCS-2 to add support for surrogate pairs and the rest of
the unicode set. All valid UCS-2 text is also valid UTF-16 text, and all
UTF-16 text not containing surrogate pairs is valid UCS-2.

We decode incoming SMS as UTF-16 instead of UCS-2 to add support for
these extended characters. We should do the same for encoding outgoing
SMS messages.
