### PR TITLE
[ofono] Fix call forwarding unconditional change signal emission.

### DIFF
--- a/ofono/src/call-forwarding.c
+++ b/ofono/src/call-forwarding.c
@@ -411,9 +411,12 @@ static void set_new_cond_list(struct ofono_call_forwarding *cf,
 				number = phone_number_to_string(
 							&lc->phone_number);
 
+			snprintf(attr, sizeof(attr), "%s%s",
+				bearer_class_to_string(lc->cls), cf_type_lut[i]);
+
 			ofono_dbus_signal_property_changed(conn, path,
 						OFONO_CALL_FORWARDING_INTERFACE,
-						cf_type_lut[i],
+						attr,
 						DBUS_TYPE_STRING, &number);
 		}
 


### PR DESCRIPTION
When toggling cfu the change signals for the other types didn't have the
prefix applied.
