### PR TITLE
Fixed compilation warnings

### DIFF
--- a/ofono/drivers/rilmodem/sms.c
+++ b/ofono/drivers/rilmodem/sms.c
@@ -390,15 +390,13 @@ static void ril_read_sms_on_sim_cb(const struct ofono_error *error,
 {
 	struct cb_data *cbd = data;
 	struct ofono_sms *sms = cbd->user;
-	int sms_len,i,record;
+	int record;
 	unsigned int smsc_len;
 
 	if (error->type != OFONO_ERROR_TYPE_NO_ERROR) {
 		ofono_error("cannot read sms from sim");
 		goto exit;
 	}
-
-	sms_len = strlen(sdata);
 
 	/*
 	 * It seems when reading EFsms RIL returns the whole record including
@@ -437,7 +435,7 @@ static void ril_new_sms_on_sim(struct ril_msg *message, gpointer user_data)
 
 	if (record > 0) {
 		record = parcel_r_int32(&rilp);
-		struct cb_data *cbd = cb_data_new2(sms, NULL, record);
+		struct cb_data *cbd = cb_data_new2(sms, NULL, (void*)record);
 		DBG(":%d", record);
 		get_sim_driver()->read_file_linear(get_sim(), SIM_EFSMS_FILEID,
 						record, EFSMS_LENGTH, path,


### PR DESCRIPTION
drivers/rilmodem/sms.c: In function 'ril_read_sms_on_sim_cb':
drivers/rilmodem/sms.c:401:2: warning: pointer targets in passing argument 1 of 'strlen' differ in signedness [-Wpointer-sign]
//usr/include/string.h:399:15: note: expected 'const char *' but argument is of type 'const unsigned char *'
drivers/rilmodem/sms.c:393:14: warning: unused variable 'i' [-Wunused-variable]
drivers/rilmodem/sms.c:393:6: warning: variable 'sms_len' set but not used [-Wunused-but-set-variable]
drivers/rilmodem/sms.c: In function 'ril_new_sms_on_sim':
drivers/rilmodem/sms.c:440:10: warning: passing argument 3 of 'cb_data_new2' makes pointer from integer without a cast [enabled by default]
drivers/rilmodem/rilutil.h:147:31: note: expected 'void *' but argument is of type 'int'
