### PR TITLE
Remove the cbs creation for n900 plugin, this lead to crashes on n9 ofon...

### DIFF
--- a/ofono/plugins/n900.c
+++ b/ofono/plugins/n900.c
@@ -507,7 +507,7 @@ static void n900_post_online(struct ofono_modem *modem)
 
 	ofono_netreg_create(modem, 0, "isimodem", isi->modem);
 	ofono_sms_create(modem, 0, "isimodem", isi->modem);
-	ofono_cbs_create(modem, 0, "isimodem", isi->modem);
+/*	ofono_cbs_create(modem, 0, "isimodem", isi->modem);*/
 	ofono_ussd_create(modem, 0, "isimodem", isi->modem);
 	ofono_call_settings_create(modem, 0, "isimodem", isi->modem);
 	ofono_call_barring_create(modem, 0, "isimodem", isi->modem);


### PR DESCRIPTION
...o init.

For the latest release of ofono for Nemo Mobile, the modem fails to initialize
with the isimodem driver enabled. This is due to a segmentation fault occurring
in the flush of the atoms of the modem in cbs_assembly_free function. This
resulted in a segmentation fault when using n900 driver.

[n900] Remove cbs creation.
