### PR TITLE
Add NetworkRegistration.OperatorsChanged signal

### DIFF
--- a/ofono/doc/network-api.txt
+++ b/ofono/doc/network-api.txt
@@ -57,6 +57,11 @@ Signals		PropertyChanged(string property, variant value)
 			This signal indicates a changed value of the given
 			property.
 
+		OperatorsChanged(array{object,dict})
+
+			Signal that gets emitted when operator list has
+			changed. It contains the current list of operators.
+
 Properties	string Mode [readonly]
 
 			The current registration mode. The default of this


### PR DESCRIPTION
This signal gets emitted when operator list has changed. It contains the current list of operators.

The network selection UI may (and does) have multiple NetworkRegistration clients. When one of them issues the Scan call and the list of operators gets updated, the other clients need to be notified, otherwise there's no way (other than polling which is utterly inefficient) that their state can reflect the reality. The new signal solves this problem.
