### PR TITLE
Emit signal when context changed

### DIFF
--- a/ofono/gril/grilunsol.c
+++ b/ofono/gril/grilunsol.c
@@ -77,6 +77,58 @@ void g_ril_unsol_free_data_call_list(struct unsol_data_call_list *unsol)
 	}
 }
 
+gboolean g_ril_unsol_cmp_dcl(struct unsol_data_call_list *current,
+				struct unsol_data_call_list *old,
+				gint cid)
+{
+	GSList *nl,*ol;
+	struct data_call *new_call, *old_call;
+
+	new_call = old_call = NULL;
+	gboolean no_cid = TRUE;
+
+
+	if (!current || !old)
+		return FALSE;
+
+	if (current->num != old->num)
+		return FALSE;
+
+	for (nl = current->call_list; nl; nl = nl->next) {
+		new_call = (struct data_call *) nl->data;
+
+		if (new_call->cid != cid)
+			continue;
+
+		for (ol = old->call_list; ol; ol = ol->next) {
+			old_call = (struct data_call *) ol->data; 
+			if(new_call->cid == old_call->cid) {
+				no_cid = FALSE;
+				break;
+			}
+		}
+		if (no_cid)
+			return FALSE;
+
+		if (new_call->active != old_call->active)
+			return FALSE;
+		if (g_strcmp0(new_call->type,old_call->type))
+			return FALSE;
+		if (g_strcmp0(new_call->ifname,old_call->ifname))
+			return FALSE;
+		if (g_strcmp0(new_call->addresses,old_call->addresses))
+			return FALSE;
+		if (g_strcmp0(new_call->dnses,old_call->dnses))
+			return FALSE;
+		if (g_strcmp0(new_call->gateways,old_call->gateways))
+			return FALSE;
+	}
+	if (no_cid)
+		return FALSE;
+
+	return TRUE;
+}
+
 struct unsol_data_call_list *g_ril_unsol_parse_data_call_list(GRil *gril,
 					struct ril_msg *message,
 					struct ofono_error *error)

--- a/ofono/gril/grilunsol.h
+++ b/ofono/gril/grilunsol.h
@@ -51,6 +51,9 @@ struct data_call {
 
 void g_ril_unsol_free_data_call_list(struct unsol_data_call_list *unsol);
 
+gboolean g_ril_unsol_cmp_dcl(struct unsol_data_call_list *current,
+				struct unsol_data_call_list *old, gint cid);
+
 struct unsol_data_call_list *g_ril_unsol_parse_data_call_list(GRil *gril,
 					struct ril_msg *message,
 					struct ofono_error *error);

--- a/ofono/include/gprs-context.h
+++ b/ofono/include/gprs-context.h
@@ -117,6 +117,10 @@ void ofono_gprs_context_set_ipv6_gateway(struct ofono_gprs_context *gc,
 						const char *gateway);
 void ofono_gprs_context_set_ipv6_dns_servers(struct ofono_gprs_context *gc,
 						const char **dns);
+
+void ofono_gprs_context_signal_change(struct ofono_gprs_context *gc,
+							unsigned int cid);
+
 #ifdef __cplusplus
 }
 #endif

--- a/ofono/src/gprs.c
+++ b/ofono/src/gprs.c
@@ -2550,6 +2550,29 @@ void ofono_gprs_context_set_ipv6_dns_servers(struct ofono_gprs_context *gc,
 	settings->ipv6->dns = g_strdupv((char **) dns);
 }
 
+void ofono_gprs_context_signal_change(struct ofono_gprs_context *gc,
+							unsigned int cid)
+{
+	GSList *l;
+	struct pri_context *ctx;
+
+	if (gc->gprs == NULL)
+		return;
+
+	for (l = gc->gprs->contexts; l; l = l->next) {
+		ctx = l->data;
+
+		if (ctx->context.cid != cid)
+			continue;
+
+		if (ctx->active == FALSE)
+			break;
+
+		pri_context_signal_settings(ctx, gc->settings->ipv4 != NULL,
+						gc->settings->ipv6 != NULL);
+	}
+}
+
 int ofono_gprs_driver_register(const struct ofono_gprs_driver *d)
 {
 	DBG("driver: %p, name: %s", d, d->name);


### PR DESCRIPTION
Currently ofono only sends context property changed signal as part of deactivation and activation. These changes allow driver to emit signal when properties have changed during the active data call/context. e.g. when in dual mode IPv6 address is received later and not as part of activation request.