### PR TITLE
[ofono] Move SCO socket allocation to hfp_hf_bluez5 plugin

### DIFF
--- a/ofono/plugins/hfp_hf_bluez5.c
+++ b/ofono/plugins/hfp_hf_bluez5.c
@@ -49,6 +49,7 @@
 #include <ofono/handsfree.h>
 #include <ofono/handsfree-audio.h>
 #include <ofono/siri.h>
+#include <ofono.h>
 
 #include <drivers/atmodem/atutil.h>
 #include <drivers/hfpmodem/slc.h>
@@ -761,6 +762,8 @@ static int hfp_init(void)
 
 	if (DBUS_TYPE_UNIX_FD < 0)
 		return -EBADF;
+
+	__ofono_handsfree_audio_manager_init();
 
 	/* Registers External Profile handler */
 	if (!g_dbus_register_interface(conn, HFP_EXT_PROFILE_PATH,

--- a/ofono/src/main.c
+++ b/ofono/src/main.c
@@ -244,7 +244,11 @@ int main(int argc, char **argv)
 
 	__ofono_manager_init();
 
-	__ofono_handsfree_audio_manager_init();
+	/*
+	 * BT HFP SCO socket creation moved to Bluez5 plugin.
+	 * Bluez4 handles the SCO socket, it will conflict with oFono.
+	 */
+	//__ofono_handsfree_audio_manager_init();
 
 	__ofono_plugin_init(option_plugin, option_noplugin);
 


### PR DESCRIPTION
SCO socket is handled by Bluez4 and conflicts with ofono's socket
allocation.