### PR TITLE
Add ResetProperties method to ConnectionContext interface

### DIFF
--- a/ofono/doc/connman-api.txt
+++ b/ofono/doc/connman-api.txt
@@ -155,6 +155,11 @@ Methods		dict GetProperties()
 					 [service].Error.AttachInProgress
 					 [service].Error.NotImplemented
 
+Methods		void ResetProperties()
+			Resets all properties back to default. The context
+			will be deactivated before any significant property
+			is updated.
+
 Signals		PropertyChanged(string property, variant value)
 
 			This signal indicates a changed value of the given


### PR DESCRIPTION
Allows to reset connection context properties back to default.