### PR TITLE
Register SimManager interface always and simplify logic

### DIFF
--- a/ofono/drivers/rilmodem/rilutil.c
+++ b/ofono/drivers/rilmodem/rilutil.c
@@ -375,7 +375,14 @@ gboolean ril_util_parse_sim_status(GRil *gril,
 	 * Do we just make a style-guide exception for PrintBuf operations?
 	 */
 	g_ril_append_print_buf(gril,
-				"(card_state=%d,universal_pin_state=%d,gsm_umts_index=%d,cdma_index=%d,ims_index=%d, ",
+				"card_state=%d,universal_pin_state=%d,gsm_umts_index=%d,cdma_index=%d,ims_index=%d, ",
+				status->card_state,
+				status->pin_state,
+				status->gsm_umts_index,
+				status->cdma_index,
+				status->ims_index);
+
+	DBG("card_state=%d, universal_pin_state=%d, gsm_umts_index=%d, cdma_index=%d, ims_index=%d",
 				status->card_state,
 				status->pin_state,
 				status->gsm_umts_index,
@@ -387,6 +394,7 @@ gboolean ril_util_parse_sim_status(GRil *gril,
 	else
 		goto done;
 
+	DBG("sim num_apps: %d", status->num_apps);
 	if (status->num_apps > MAX_UICC_APPS) {
 		ofono_error("SIM error; too many apps: %d", status->num_apps);
 		status->num_apps = MAX_UICC_APPS;
@@ -403,6 +411,8 @@ gboolean ril_util_parse_sim_status(GRil *gril,
 		apps[i]->app_type = parcel_r_int32(&rilp);
 		apps[i]->app_state = parcel_r_int32(&rilp);
 
+		DBG("app[%d]: app_type: %d, app_state: %d", i,
+				apps[i]->app_type, apps[i]->app_state);
 		/*
 		 * Consider RIL_APPSTATE_ILLEGAL also READY. Even if app state
 		 * is  RIL_APPSTATE_ILLEGAL (-1), ICC operations must be
@@ -430,6 +440,16 @@ gboolean ril_util_parse_sim_status(GRil *gril,
 					"%s[app_type=%d,app_state=%d,perso_substate=%d,aid_ptr=%s,app_label_ptr=%s,pin1_replaced=%d,pin1=%d,pin2=%d],",
 					print_buf,
 					apps[i]->app_type,
+					apps[i]->app_state,
+					apps[i]->perso_substate,
+					apps[i]->aid_str,
+					apps[i]->app_str,
+					apps[i]->pin_replaced,
+					apps[i]->pin1_state,
+					apps[i]->pin2_state);
+
+		DBG("app[%d]: type=%d, state=%d, perso_substate=%d, aid_ptr=%s, app_label_ptr=%s, pin1_replaced=%d, pin1=%d, pin2=%d",
+					i, apps[i]->app_type,
 					apps[i]->app_state,
 					apps[i]->perso_substate,
 					apps[i]->aid_str,
@@ -606,8 +626,10 @@ gint ril_util_parse_sms_response(GRil *gril, struct ril_msg *message)
 	 */
 	mr = parcel_r_int32(&rilp);
 	ack_pdu = parcel_r_string(&rilp);
-	error = parcel_r_int32(&rilp);
 
+	/* error: 3GPP 27.005, 3.2.5, -1 if unknown or not applicable */
+	error = parcel_r_int32(&rilp);
+	DBG("sms msg ref: %d, error: %d, ack_pdu: %s", mr, error, ack_pdu);
 
 	g_ril_append_print_buf(gril, "{%d,%s,%d}",
 				mr, ack_pdu, error);

--- a/ofono/drivers/rilmodem/sim.c
+++ b/ofono/drivers/rilmodem/sim.c
@@ -97,11 +97,9 @@ struct sim_data {
 	guint app_type;
 	gchar *app_str;
 	guint app_index;
-	gboolean sim_registered;
 	enum ofono_sim_password_type passwd_type;
 	int retries[OFONO_SIM_PASSWORD_INVALID];
 	enum ofono_sim_password_type passwd_state;
-	guint card_state;
 	guint idle_id;
 	gboolean initialized;
 	gboolean removed;
@@ -187,7 +185,7 @@ static void ril_file_info_cb(struct ril_msg *message, gpointer user_data)
 	 * core will crash.
 	 */
 	if (sd->removed == TRUE) {
-		ofono_error("RIL_CARDSTATE_ABSENT");
+		ofono_error("%s RIL_CARDSTATE_ABSENT", __func__);
 		return;
 	}
 
@@ -637,13 +635,10 @@ static void sim_status_cb(struct ril_msg *message, gpointer user_data)
 	guint search_index = -1;
 	struct parcel rilp;
 
-	DBG("");
+	DBG("%p", message);
 
 	if (ril_util_parse_sim_status(sd->ril, message, &status, apps) &&
 		status.num_apps) {
-
-		DBG("num_apps: %d gsm_umts_index: %d", status.num_apps,
-			status.gsm_umts_index);
 
 		/* TODO(CDMA): need some kind of logic to
 		 * set the correct app_index,
@@ -660,25 +655,24 @@ static void sim_status_cb(struct ril_msg *message, gpointer user_data)
 			}
 		}
 
-		if (sd->sim_registered == FALSE) {
-			ofono_sim_register(sim);
-			sd->sim_registered = TRUE;
-		} else {
-			/* TODO: There doesn't seem to be any other
-			 * way to force the core SIM code to
-			 * recheck the PIN.
-			 * Wouldn't __ofono_sim_refresh be
-			 * more appropriate call here??
-			 * __ofono_sim_refresh(sim, NULL, TRUE, TRUE);
-			 */
-			DBG("sd->card_state:%u", sd->card_state);
-			if (sd->card_state != RIL_CARDSTATE_PRESENT) {
-				ofono_sim_inserted_notify(sim, TRUE);
-				sd->card_state = RIL_CARDSTATE_PRESENT;
-				sd->removed = FALSE;
-			}
-		}
+		/*
+		 * ril_util_parse_sim_status returns true only when
+		 * card status is RIL_CARDSTATE_PRESENT so notify TRUE always.
+		 *
+		 * ofono_sim_inserted_notify skips and returns if
+		 * present/not_present status doesn't change from previous.
+		 */
+		ofono_sim_inserted_notify(sim, TRUE);
 
+		sd->removed = FALSE;
+
+		/* TODO: There doesn't seem to be any other
+		 * way to force the core SIM code to
+		 * recheck the PIN.
+		 * Wouldn't __ofono_sim_refresh be
+		 * more appropriate call here??
+		 * __ofono_sim_refresh(sim, NULL, TRUE, TRUE);
+		 */
 		__ofono_sim_recheck_pin(sim);
 
 		if (current_online_state == RIL_ONLINE_PREF) {
@@ -705,19 +699,14 @@ static void sim_status_cb(struct ril_msg *message, gpointer user_data)
 			current_online_state = RIL_ONLINE_PREF;
 
 		if (status.card_state == RIL_CARDSTATE_ABSENT) {
-			DBG("sd->card_state:%u,status.card_state:%u,",
-				sd->card_state, status.card_state);
-			ofono_info("RIL_CARDSTATE_ABSENT");
-			ofono_sim_inserted_notify(sim, FALSE);
-			if (sd->card_state == RIL_CARDSTATE_PRESENT)
-				sd->removed = TRUE;
-			sd->card_state = RIL_CARDSTATE_ABSENT;
+			ofono_info("%s: RIL_CARDSTATE_ABSENT", __func__);
 
+			ofono_sim_inserted_notify(sim, FALSE);
+
+			sd->removed = TRUE;
 			sd->initialized = FALSE;
 		}
 	}
-
-	/* TODO: if no SIM present, handle emergency calling. */
 }
 
 static int send_get_sim_status(struct ofono_sim *sim)
@@ -769,9 +758,6 @@ static void ril_query_passwd_state_cb(struct ril_msg *message, gpointer user_dat
 
 	if (ril_util_parse_sim_status(sd->ril, message, &status, apps) &&
 		status.num_apps) {
-
-		DBG("num_apps: %d gsm_umts_index: %d", status.num_apps,
-			status.gsm_umts_index);
 
 		/* TODO(CDMA): need some kind of logic to
 		 * set the correct app_index,
@@ -1117,15 +1103,14 @@ static gboolean ril_sim_register(gpointer user)
 
 	DBG("");
 
-	sd->idle_id = 0;
+	ofono_sim_register(sim);
 
 	send_get_sim_status(sim);
 
-	g_ril_register(sd->ril, RIL_UNSOL_RESPONSE_SIM_STATUS_CHANGED,
+	sd->idle_id = 0;
+	sd->idle_id = g_ril_register(sd->ril,
+			RIL_UNSOL_RESPONSE_SIM_STATUS_CHANGED,
 			(GRilNotifyFunc) ril_sim_status_changed, sim);
-
-	/* TODO: should we also register for RIL_UNSOL_SIM_REFRESH? */
-
 	return FALSE;
 }
 

--- a/ofono/drivers/rilmodem/sim.c
+++ b/ofono/drivers/rilmodem/sim.c
@@ -126,7 +126,8 @@ static void set_path(struct sim_data *sd, struct parcel *rilp,
 	} else if (sd->app_type == RIL_APPTYPE_SIM) {
 		len = sim_ef_db_get_path_2g(fileid, db_path);
 	} else {
-		ofono_error("Unsupported app_type: 0%x", sd->app_type);
+		ofono_error("%s Unsupported app_type: 0%x", __func__,
+				sd->app_type);
 	}
 
 	if (len > 0) {
@@ -203,14 +204,15 @@ static void ril_file_info_cb(struct ril_msg *message, gpointer user_data)
 						&sw1,
 						&sw2,
 						&response_len)) == NULL) {
-		ofono_error("Can't parse SIM IO response from RILD");
+		ofono_error("%s Can't parse SIM IO response", __func__);
 		decode_ril_error(&error, "FAIL");
 		goto error;
 	}
 
 	if ((sw1 != 0x90 && sw1 != 0x91 && sw1 != 0x92 && sw1 != 0x9f) ||
 		(sw1 == 0x90 && sw2 != 0x00)) {
-		ofono_error("invalid values: sw1: %02x sw2: %02x", sw1, sw2);
+		ofono_error("%s invalid values: sw1: %02x sw2: %02x", __func__,
+				sw1, sw2);
 		memset(&error, 0, sizeof(error));
 
 		/* TODO: fix decode_ril_error to take type & error */
@@ -233,7 +235,7 @@ static void ril_file_info_cb(struct ril_msg *message, gpointer user_data)
 	}
 
 	if (!ok) {
-		ofono_error("parse response failed");
+		ofono_error("%s parse response failed", __func__);
 		decode_ril_error(&error, "FAIL");
 		goto error;
 	}
@@ -323,7 +325,7 @@ static void ril_file_io_cb(struct ril_msg *message, gpointer user_data)
 	if (message->error == RIL_E_SUCCESS) {
 		decode_ril_error(&error, "OK");
 	} else {
-		ofono_error("RILD reply failure: %s",
+		ofono_error("%s RILD reply failure: %s", __func__,
 				ril_error_to_string(message->error));
 		goto error;
 	}
@@ -334,7 +336,7 @@ static void ril_file_io_cb(struct ril_msg *message, gpointer user_data)
 						&sw1,
 						&sw2,
 						&response_len)) == NULL) {
-		ofono_error("Error parsing IO response");
+		ofono_error("%s Error parsing IO response", __func__);
 		goto error;
 	}
 
@@ -468,7 +470,7 @@ static void ril_imsi_cb(struct ril_msg *message, gpointer user_data)
 		DBG("GET IMSI reply - OK");
 		decode_ril_error(&error, "OK");
 	} else {
-		ofono_error("Reply failure: %s",
+		ofono_error("%s Reply failure: %s", __func__,
 			    ril_error_to_string(message->error));
 		decode_ril_error(&error, "FAIL");
 		cb(&error, NULL, cbd->data);

--- a/ofono/plugins/ril.c
+++ b/ofono/plugins/ril.c
@@ -91,7 +91,6 @@ struct ril_data {
 	int power_on_retries;
 	int sim_status_retries;
 	ofono_bool_t connected;
-	ofono_bool_t have_sim;
 	ofono_bool_t online;
 	ofono_bool_t reported;
 	guint timer_id;
@@ -141,15 +140,12 @@ static void sim_status_cb(struct ril_msg *message, gpointer user_data)
 		else
 			ofono_error("Max retries for GET_SIM_STATUS exceeded!");
 	} else {
-
 		/* Returns TRUE if cardstate == PRESENT */
 		if (ril_util_parse_sim_status(ril->modem, message,
 						&status, apps)) {
 
 			if (status.num_apps)
 				ril_util_free_sim_apps(apps, status.num_apps);
-
-			ril->have_sim = TRUE;
 		} else {
 			ofono_warn("No SIM card present.");
 		}
@@ -235,13 +231,8 @@ static void ril_pre_sim(struct ofono_modem *modem)
 {
 	DBG("");
 	struct ril_data *ril = ofono_modem_get_data(modem);
-	struct ofono_sim *sim;
-
-	sim = ofono_sim_create(modem, 0, "rilmodem", ril->modem);
+	ofono_sim_create(modem, 0, "rilmodem", ril->modem);
 	ofono_voicecall_create(modem, 0, "rilmodem", ril->modem);
-
-	if (sim && ril->have_sim)
-		ofono_sim_inserted_notify(sim, TRUE);
 }
 
 static void ril_post_sim(struct ofono_modem *modem)
@@ -488,8 +479,6 @@ static int create_gril(struct ofono_modem *modem)
 {
 	DBG(" modem: %p", modem);
 	struct ril_data *ril = ofono_modem_get_data(modem);
-
-	ril->have_sim = FALSE;
 
 	/* RIL expects user radio */
 	ril_switchUser();

--- a/ofono/plugins/ril.c
+++ b/ofono/plugins/ril.c
@@ -145,8 +145,6 @@ static void sim_status_cb(struct ril_msg *message, gpointer user_data)
 		/* Returns TRUE if cardstate == PRESENT */
 		if (ril_util_parse_sim_status(ril->modem, message,
 						&status, apps)) {
-			DBG("have_sim = TRUE; num_apps: %d",
-				status.num_apps);
 
 			if (status.num_apps)
 				ril_util_free_sim_apps(apps, status.num_apps);


### PR DESCRIPTION
- Register org.ofono.SimManager always, without this the dbus interface does not exist when starting without a SIM card. With this change it's more logical: interface is always there and clients should monitor the "Present" property for SIM removal or insertion.
- Additional changes: simplified rilmodem SIM status handling and debug logging improvements
 