### PR TITLE
Fix memory leak

### DIFF
--- a/ofono/drivers/rilmodem/phonebook.c
+++ b/ofono/drivers/rilmodem/phonebook.c
@@ -292,20 +292,17 @@ void handle_sne(size_t len, const unsigned char *msg, char *sne)
 				list_entry->data;
 
 			if (entry) {
-				/* If one already exists,
-						delete it */
-				if (entry->sne)
-					g_free(entry->sne);
-
 				DBG("Adding SNE to entry %d",
 					phonebook_entry_nbr);
 				DBG("name %s", entry->name);
 
+				g_free(entry->sne);
 				entry->sne = sne;
-			} else {
-				g_free(sne);
+				return;
 			}
 		}
+
+		g_free(sne);
 	}
 }
 


### PR DESCRIPTION
```
==25834== 50 bytes in 50 blocks are definitely lost in loss record 98 of 146
==25834==    at 0x483F380: malloc (vg_replace_malloc.c:296)
==25834==    by 0xE0583: sim_string_to_utf8 (util.c:1334)
==25834==    by 0x32167: handle_sne (phonebook.c:278)
==25834==    by 0x32D17: decode_read_response (phonebook.c:581)
==25834==    by 0x33847: pb_content_data_cb (phonebook.c:849)
==25834==    by 0x2B643: ril_file_io_cb (sim.c:343)
==25834==    by 0x1BC57: handle_response (gril.c:379)
==25834==    by 0x1C10B: dispatch (gril.c:524)
==25834==    by 0x1C3E7: new_bytes (gril.c:615)
==25834==    by 0x1DDC3: received_data (grilio.c:126)
==25834==    by 0x48CCB85: g_main_dispatch (gmain.c:3066)
==25834==    by 0x48CCB85: g_main_context_dispatch (gmain.c:3642)
==25834==    by 0x48CCE11: g_main_context_iterate.isra.5 (gmain.c:3713)
==25834==    by 0x48CD1D3: g_main_loop_run (gmain.c:3907)
==25834==    by 0xD63DB: main (main.c:258)
```