### PR TITLE
[sim] Reset ofono pin state to none when card removed

### DIFF
--- a/ofono/src/sim.c
+++ b/ofono/src/sim.c
@@ -2514,7 +2514,7 @@ void ofono_sim_inserted_notify(struct ofono_sim *sim, ofono_bool_t inserted)
 		 * when sim state changes to OFONO_SIM_STATE_LOCKED_OUT
 		 * (PUK lock) if user fails to change PIN.
 		 */
-		sim->pin_type = OFONO_SIM_PASSWORD_INVALID;
+		sim->pin_type = OFONO_SIM_PASSWORD_NONE;
 
 		sim_free_state(sim);
 	}

--- a/ofono/src/sim.c
+++ b/ofono/src/sim.c
@@ -2784,17 +2784,19 @@ static void sim_pin_query_cb(const struct ofono_error *error,
 
 		if (pin_type != OFONO_SIM_PASSWORD_INVALID) {
 			lock_changed = !sim->locked_pins[pin_type];
+
 			sim->locked_pins[pin_type] = TRUE;
 
 			if (lock_changed) {
 				locked_pins = get_locked_pins(sim);
+
 				ofono_dbus_signal_array_property_changed(conn,
 						path,
 						OFONO_SIM_MANAGER_INTERFACE,
 						"LockedPins", DBUS_TYPE_STRING,
 						&locked_pins);
+
 				g_strfreev(locked_pins);
-				locked_pins = NULL;
 			}
 		}
 		ofono_dbus_signal_property_changed(conn, path,


### PR DESCRIPTION
sim_get_properties would have problems with OFONO_SIM_PASSWORD_INVALID.