### PR TITLE
Read RILD command socket path from a conf file. MER#1107

### DIFF
--- a/ofono/gril/gril.h
+++ b/ofono/gril/gril.h
@@ -93,7 +93,7 @@ extern char print_buf[];
 
 void g_ril_init_parcel(struct ril_msg *message, struct parcel *rilp);
 
-GRil *g_ril_new();
+GRil *g_ril_new(const char *sockpath);
 
 GIOChannel *g_ril_get_channel(GRil *ril);
 GRilIO *g_ril_get_io(GRil *ril);


### PR DESCRIPTION
This allows configuring at startup the RILD command socket path to which oFono gril and rilmodem will connect to.
One of the enablers for multi-sim.